### PR TITLE
Initial pass to a Free based DSL built on `kategory`

### DIFF
--- a/uiagesturegen/build.gradle
+++ b/uiagesturegen/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.1.2-4'
+    ext.kotlinVersion = '1.1.3'
 
     repositories {
         mavenCentral()
@@ -47,7 +47,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+    compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
     compile 'com.android.support:appcompat-v7:25.3.1'
     testCompile 'junit:junit:4.12'
     compile 'io.kategory:kategory:0.3.3'

--- a/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/dsl.kt
+++ b/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/dsl.kt
@@ -23,7 +23,7 @@ class SafeInterpreter<F>(val M: MonadError<F, Throwable>, val device: UiDevice) 
     override fun <A> invoke(fa: HK<GestureDSL.F, A>): HK<F, A> {
         val g = fa.ev()
         return when (g) {
-            is GestureDSL.PressHome -> M.pure(device.pressHome())
+            is GestureDSL.PressHome -> M.pure(device.pressHome()) // all M.pure should be changed to M.catch once that is available in Kategory
             is GestureDSL.Wait<*> -> M.pure(device.wait(g.condition, g.timeout))
             is GestureDSL.FindObject -> M.pure(device.findObject(g.selector))
             is GestureDSL.WithDevice<*> -> M.pure(g.f(device))

--- a/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/dsl.kt
+++ b/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/dsl.kt
@@ -1,0 +1,59 @@
+package com.pguardiola.uigesturegen.dsl
+
+import android.support.test.uiautomator.*
+import kategory.*
+
+typealias DSLAction<A> = Free<GestureDSL.F, A>
+
+sealed class GestureDSL<out A> : HK<GestureDSL.F, A> {
+
+    class F private constructor()
+
+    object PressHome : GestureDSL<Boolean>()
+    data class Wait<R>(val condition: SearchCondition<R>, val timeout: Long) : GestureDSL<R>()
+    data class FindObject(val selector: UiSelector) : GestureDSL<UiObject>()
+    data class WithDevice<out A>(val f: (UiDevice) -> A) : GestureDSL<A>()
+
+    companion object : FreeMonad<GestureDSL.F>
+
+}
+
+@Suppress("UNCHECKED_CAST")
+class SafeInterpreter<F>(val M: MonadError<F, Throwable>, val device: UiDevice) : FunctionK<GestureDSL.F, F> {
+    override fun <A> invoke(fa: HK<GestureDSL.F, A>): HK<F, A> {
+        val g = fa.ev()
+        return when (g) {
+            is GestureDSL.PressHome -> M.pure(device.pressHome())
+            is GestureDSL.Wait<*> -> M.pure(device.wait(g.condition, g.timeout))
+            is GestureDSL.FindObject -> M.pure(device.findObject(g.selector))
+            is GestureDSL.WithDevice<*> -> M.pure(g.f(device))
+        } as HK<F, A>
+    }
+}
+
+fun <A> HK<GestureDSL.F, A>.ev(): GestureDSL<A> = this as GestureDSL<A>
+
+inline fun <reified G, A, B> List<A>.traverse(crossinline f: (A) -> HK<G, B>, AP: Applicative<G> = applicative<G>()): HK<G, List<B>> =
+        foldRight(AP.pure<List<B>>(emptyList()), { a: A, lglb: HK<G, List<B>> ->
+            AP.map2(f(a), lglb, { it.b + it.a })
+        })
+
+inline fun <reified G, A> List<HK<G, A>>.sequence(AP: Applicative<G>): HK<G, List<A>> =
+        traverse({ a -> a }, AP)
+
+inline fun <A> List<DSLAction<A>>.sequence(): DSLAction<List<A>> =
+        sequence(GestureDSL).ev()
+
+fun <A, B> List<DSLAction<A>>.transform(f: (A) -> B): DSLAction<List<B>> =
+        sequence(GestureDSL).ev().map { list -> list.map(f) }
+
+fun pressHome(): DSLAction<Boolean> = Free.liftF(GestureDSL.PressHome)
+fun <R> wait(condition: SearchCondition<R>, timeout: Long): DSLAction<R> = Free.liftF(GestureDSL.Wait(condition, timeout))
+fun findObject(selector: UiSelector): DSLAction<UiObject> = Free.liftF(GestureDSL.FindObject(selector))
+fun <A> withDevice(f: (UiDevice) -> A): DSLAction<A> = Free.liftF(GestureDSL.WithDevice(f))
+
+fun <A> Free<GestureDSL.F, A>.run(device: UiDevice): Try<A> =
+        this.foldMap(SafeInterpreter(Try, device), Try).ev()
+
+fun <A> Free<GestureDSL.F, A>.unsafeRun(device: UiDevice): A =
+        run(device).fold({ e -> throw e }, { it })

--- a/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/examples.kt
+++ b/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/examples.kt
@@ -1,0 +1,63 @@
+package com.pguardiola.uigesturegen.dsl
+
+import android.support.test.uiautomator.UiDevice
+import android.support.test.uiautomator.UiObject
+import android.support.test.uiautomator.UiSelector
+
+import kategory.*
+
+object GestureDSLExamples {
+
+    /**
+     * compose multiple actions independently regardless of return types
+     */
+    fun independentActionsWorkflow(): DSLAction<Tuple4<Boolean, UiObject, UiObject, UiObject>> =
+            GestureDSL.tupled(
+                    pressHome(),
+                    findObject(UiSelector().description("1")),
+                    findObject(UiSelector().description("2")),
+                    findObject(UiSelector().description("3"))).ev()
+
+
+    /**
+     * compose actions based on results of other actions
+     */
+    fun dependentActionsWorkflow(): DSLAction<UiObject> = GestureDSL.binding {
+        val homePressed = !pressHome()
+        val ui = !if (homePressed) {
+            findObject(UiSelector().description("1"))
+        } else {
+            findObject(UiSelector().description("2"))
+        }
+        yields(ui)
+    }.ev()
+
+    /**
+     * Create a bigger action from smaller actions
+     */
+    fun uberAction(): DSLAction<List<UiObject>> = listOf(
+            findObject(UiSelector().description("1")),
+            findObject(UiSelector().description("2"))).sequence()
+
+    /**
+     * Map over multiple actions of the same type extracting inner values or performing effects
+     */
+    fun mappedAction(): DSLAction<List<Boolean>> = listOf(
+            findObject(UiSelector().description("1")),
+            findObject(UiSelector().description("2"))).transform {
+        it.longClick()
+    }
+
+    fun runAll() = {
+        val program = GestureDSL.tupled(
+                independentActionsWorkflow(),
+                dependentActionsWorkflow(),
+                uberAction(),
+                mappedAction()).ev()
+        //handle errors in the workflow appropriately, or unsafeRun to bubble up exceptions
+        // Notice how the device is just passed to the workflow at the end
+        // the entire program is also stack safe because is built a top of the Free monad which reifies ops in memory
+        program.run(UiDevice.getInstance()).recover { e -> throw e }
+    }
+
+}


### PR DESCRIPTION
The following POC DSL brings the following features:

- [x] Purely functional and stack-safe based on [kategory Free monads](https://github.com/kategory/kategory) 
- [x] Allows deferring dependency on `UiDevice` until the point of execution.
- [x] Safe and unsafe combinators to run workflows that produce results as `Try<A>` or `A`
- [x] list `traverse`, `sequence` and `transform` combinators to unify and combine operations as an uber operation and transform internal references.

Some examples here and included in the PR for illustration purposes:
```kotlin
/**
 * compose multiple actions independently regardless of return types
 */
fun independentActionsWorkflow() =
        GestureDSL.tupled(
                pressHome(),
                findObject(UiSelector().description("1")),
                findObject(UiSelector().description("2")),
                findObject(UiSelector().description("3"))).ev()


/**
 * compose actions based on results of other actions
 */
fun dependentActionsWorkflow() = GestureDSL.binding {
    val homePressed = !pressHome()
    val ui = !if (homePressed) {
        findObject(UiSelector().description("1"))
    } else {
        findObject(UiSelector().description("2"))
    }
    yields(ui)
}.ev()

/**
 * Create a bigger action from smaller actions
 */
fun uberAction() = listOf(
        findObject(UiSelector().description("1")),
        findObject(UiSelector().description("2"))).sequence()

/**
 * Map over multiple actions of the same type extracting inner values or performing effects
 */
fun mappedAction() = listOf(
        findObject(UiSelector().description("1")),
        findObject(UiSelector().description("2"))).transform {
    it.longClick()
}

fun runAll() = {
    val program = GestureDSL.tupled(
            independentActionsWorkflow(),
            dependentActionsWorkflow(),
            uberAction(),
            mappedAction()).ev()
    //handle errors in the workflow appropriately, or unsafeRun to bubble up exceptions
    // Notice how the device is just passed to the workflow at the end
    // the entire program is also stack safe because is built a top of the Free monad which reifies ops in memory
    program.run(UiDevice.getInstance()).recover { e -> throw e }
}
```