### PR TITLE
Click and DoubleTap actions

### DIFF
--- a/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/dsl.kt
+++ b/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/dsl.kt
@@ -55,6 +55,21 @@ fun findObject(selector: UiSelector): DSLAction<UiObject> = Free.liftF(GestureDS
 fun <A> withDevice(f: (UiDevice) -> A): DSLAction<A> = Free.liftF(GestureDSL.WithDevice(f))
 fun pressMenu(): DSLAction<Boolean> = Free.liftF(GestureDSL.PressMenu)
 
+fun DSLAction<UiObject>.click(): DSLAction<Boolean> =
+        this.map { it.click() }
+
+fun List<DSLAction<UiObject>>.click(): DSLAction<List<Boolean>> =
+        this.traverse({ it.click() }, GestureDSL).ev()
+
+fun DSLAction<UiObject>.doubleTap(): DSLAction<Boolean> =
+        click().flatMap { firstClick ->
+            if (firstClick) click()
+            else GestureDSL.pure(false)
+        }
+
+fun List<DSLAction<UiObject>>.doubleTap(): DSLAction<List<Boolean>> =
+        this.traverse({ it.doubleTap() }, GestureDSL).ev()
+
 fun <A> Free<GestureDSL.F, A>.run(device: UiDevice): Try<A> =
         this.foldMap(SafeInterpreter(Try, device), Try).ev()
 

--- a/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/examples.kt
+++ b/uiagesturegen/src/main/kotlin/com/pguardiola/uigesturegen/dsl/examples.kt
@@ -61,4 +61,14 @@ object GestureDSLExamples {
         program.run(UiDevice.getInstance()).recover { e -> throw e }
     }
 
+    fun clickExamples(): DSLAction<List<Boolean>> = listOf(
+            findObject(UiSelector().description("1")),
+            findObject(UiSelector().description("2"))).click()
+
+    fun doubleTapExamples(): DSLAction<List<Boolean>> = listOf(
+            findObject(UiSelector().description("1")),
+            findObject(UiSelector().description("2"))).doubleTap()
+
+    fun singleClick(): DSLAction<Boolean> = findObject(UiSelector().description("1")).click()
+
 }


### PR DESCRIPTION
Addresses #10 #4 #3 

Added two new action simply using extension functions. this actions `click()` and `doubleTap` can operate both over single `UiObject` or lists of `UiObject` actions. Note that regardless of this language and the fluid DSL style nothing is executed until you run and pass it a `UiDevice`

```kotlin
fun clickExamples(): DSLAction<List<Boolean>> = listOf(
            findObject(UiSelector().description("1")),
            findObject(UiSelector().description("2"))).click()

fun doubleTapExamples(): DSLAction<List<Boolean>> = listOf(
            findObject(UiSelector().description("1")),
            findObject(UiSelector().description("2"))).doubleTap()

fun singleClick(): DSLAction<Boolean> = 
            findObject(UiSelector().description("1")).click()
```

Since we are operating in a monadic context and building the instructions of our program we have to model operations in terms of `flatMap` which represents the next step the program will evaluate. Once the previous one is finished. 

Since `doubleTap` means `click` + `click` only if the first click has been successful we implement it like this:
```kotlin
fun DSLAction<UiObject>.doubleTap(): DSLAction<Boolean> =
        click().flatMap { firstClick ->
            if (firstClick) click()
            else GestureDSL.pure(false)
        }
```